### PR TITLE
Editor fixes

### DIFF
--- a/HPL2/core/sources/impl/LowLevelGraphicsSDL.cpp
+++ b/HPL2/core/sources/impl/LowLevelGraphicsSDL.cpp
@@ -1059,7 +1059,7 @@ namespace hpl {
 	{
 		;
 
-	//	glFinish();
+		glFinish();
 		//dont use this any more, SwapBuffers() takes care of it
 	}
 

--- a/HPL2/tools/editors/common/EditorBaseClasses.cpp
+++ b/HPL2/tools/editors/common/EditorBaseClasses.cpp
@@ -830,7 +830,7 @@ cEngine* iEditorBase::Init(cEngine* apEngine, bool abDestroyEngineOnExit)
 
 		mpEngine = CreateHPLEngine(eHplAPI_OpenGL, eHplSetup_All, &vars);
 		mpEngine->GetInput()->GetLowLevel()->LockInput(false);
-		gpEngine->GetInput()->GetLowLevel()->RelativeMouse(false);
+		mpEngine->GetInput()->GetLowLevel()->RelativeMouse(false);
 
 		mpEngine->GetResources()->GetMaterialManager()->SetTextureSizeDownScaleLevel(cString::ToInt(GetSetting("TexQuality").c_str(), 0));
 

--- a/HPL2/tools/editors/leveleditor/LevelEditorWindowGroup.cpp
+++ b/HPL2/tools/editors/leveleditor/LevelEditorWindowGroup.cpp
@@ -221,6 +221,7 @@ void cLevelEditorWindowGroup::OnInitLayout()
 	mpListGroups = mpSet->CreateWidgetListBox(cVector3f(10,50,1), cVector2f(250,340), mpWindow);
 	mpListGroups->SetDefaultFontSize(vTextSize);
 	mpListGroups->AddCallback(eGuiMessage_SelectionChange, this, kGuiCallback(GroupList_OnSelectionChange));
+	AddWidget(mpListGroups);
 
 	mpListGroupEntities = mpSet->CreateWidgetMultiPropertyListBox(cVector3f(270,50,1), cVector2f(340,340), mpWindow);
 	mpListGroupEntities->SetDefaultFontSize(vTextSize);
@@ -228,6 +229,7 @@ void cLevelEditorWindowGroup::OnInitLayout()
 	mpListGroupEntities->AddCallback(eGuiMessage_SelectionChange, this, kGuiCallback(EntityList_OnSelectionChange));
 	mpListGroupEntities->AddColumn("Name", 0);
 	mpListGroupEntities->SetColumnWidth(0,340);
+	AddWidget(mpListGroupEntities);
 
 	cWidgetLabel* pLabelParams = mpSet->CreateWidgetLabel(cVector3f(10,400,0.1f), 0, _W("Group parameters"), mpWindow);
 	pLabelParams->SetDefaultFontSize(vTextSize);
@@ -241,6 +243,7 @@ void cLevelEditorWindowGroup::OnInitLayout()
 	mpCheckBoxGroupVisibility = mpSet->CreateWidgetCheckBox(cVector3f(10,450,0.1f), 0, _W("Visible"),mpWindow);
 	mpCheckBoxGroupVisibility->SetDefaultFontSize(vTextSize);
 	mpCheckBoxGroupVisibility->AddCallback(eGuiMessage_CheckChange, this, kGuiCallback(VisibilityCheckBox_OnChange));
+	AddWidget(mpCheckBoxGroupVisibility);
 
 	mpEditor->SetLayoutNeedsUpdate(true);
 }

--- a/HPL2/tools/editors/leveleditor/LevelEditorWindowLevelSettings.cpp
+++ b/HPL2/tools/editors/leveleditor/LevelEditorWindowLevelSettings.cpp
@@ -73,6 +73,7 @@ void cLevelEditorWindowLevelSettings::OnInitLayout()
 	mpWindow->SetText(_W("Level Settings"));
 
 	cWidgetTabFrame* pTabFrame = mpSet->CreateWidgetTabFrame(cVector3f(10,35,0.1f), mvSize-cVector2f(20,40), _W(""), mpWindow);
+	AddWidget(pTabFrame);
 	
 	////////////////////////////////////////////////////////
 	// SkyBox parameters tab
@@ -123,7 +124,7 @@ void cLevelEditorWindowLevelSettings::OnInitLayout()
 	vPos.x += mpInpGlobalMaxDecalTris->GetSize().x + 15;
 	mpBResetDecals = mpSet->CreateWidgetButton(vPos, cVector2f(100,20), _W("Reset created decals"), pTab);
 	mpBResetDecals->AddCallback(eGuiMessage_ButtonPressed, this, kGuiCallback(ResetDecals));
-
+	AddWidget(mpBResetDecals);
 }
 
 //---------------------------------------------------------------------------------

--- a/HPL2/tools/editors/modeleditor/ModelEditorWindowPhysicsTest.cpp
+++ b/HPL2/tools/editors/modeleditor/ModelEditorWindowPhysicsTest.cpp
@@ -529,7 +529,7 @@ bool cModelEditorWindowPhysicsTest::OnViewportUpdate(const cGuiMessageData& aDat
 		mpSet->SetAttentionWidget(mpImgViewport);
 
 		pInput->GetLowLevel()->LockInput(true);
-		pInput->GetLowLevel()->MouseRelative(true);
+		pInput->GetLowLevel()->RelativeMouse(true);
 	}
 	else if(mbViewMode==false && mpSet->GetAttentionWidget()==mpImgViewport)
 	{
@@ -537,7 +537,7 @@ bool cModelEditorWindowPhysicsTest::OnViewportUpdate(const cGuiMessageData& aDat
 		mpPrevAttention = NULL;
 
 		pInput->GetLowLevel()->LockInput(false);
-		pInput->GetLowLevel()->MouseRelative(false);
+		pInput->GetLowLevel()->RelativeMouse(false);
 
 		mCamera.SetTumbleActive(false);
 		mCamera.SetTrackActive(false);
@@ -651,7 +651,7 @@ bool cModelEditorWindowPhysicsTest::OnViewportMouseUp(const cGuiMessageData& aDa
 	}
 
 	pInput->GetLowLevel()->LockInput(false);
-	pInput->GetLowLevel()->MouseRelative(false);
+	pInput->GetLowLevel()->RelativeMouse(false);
 
 	if(mbViewMode)
 	{

--- a/HPL2/tools/mapview/MapView.cpp
+++ b/HPL2/tools/mapview/MapView.cpp
@@ -652,6 +652,8 @@ public:
 		gpSimpleCamera->GetViewport()->AddRendererCallback(&renderCallback);
 		
 		gpSimpleCamera->SetMouseMode(true);
+		gpEngine->GetInput()->GetLowLevel()->LockInput(false);
+		gpEngine->GetInput()->GetLowLevel()->RelativeMouse(false);
 
 		//pSettings->mbLog = true;
 

--- a/HPL2/tools/mapview/MapView.cpp
+++ b/HPL2/tools/mapview/MapView.cpp
@@ -2032,7 +2032,7 @@ int hplMain(const tString &asCommandline)
 	vars.mGraphics.mbFullscreen = gpConfig->GetBool("Screen","FullScreen", false);
 	gpEngine = CreateHPLEngine(eHplAPI_OpenGL, eHplSetup_All, &vars);
 	gpEngine->SetLimitFPS(false);
-	gpEngine->GetGraphics()->GetLowLevel()->SetVsyncActive(false);
+	gpEngine->GetGraphics()->GetLowLevel()->SetVsyncActive(false, false);
 	gpEngine->SetWaitIfAppOutOfFocus(true);
 
 	gsNodeCont_Name = gpConfig->GetString("NodeCont","Name", "MapViewTest");

--- a/HPL2/tools/modelview/ModelView.cpp
+++ b/HPL2/tools/modelview/ModelView.cpp
@@ -979,7 +979,7 @@ public:
 		else
 			SetPhysicsActive(gbPhysicsActive);
 
-		cPlatform::SetWindowCaption("ModelView - "+cString::GetFileName(asFileName));
+		mpLowLevelGraphics->SetWindowCaption("ModelView - "+cString::GetFileName(asFileName));
 
 		Log("--------- MODEL INFO ------------------\n");
 
@@ -2396,7 +2396,7 @@ int hplMain(const tString &asCommandline)
 	//vars.mGraphics.mvWindowPosition = cVector2l(0,0);
 	gpEngine = CreateHPLEngine(eHplAPI_OpenGL, eHplSetup_All, &vars);
 	gpEngine->SetLimitFPS(false);
-	gpEngine->GetGraphics()->GetLowLevel()->SetVsyncActive(false);
+	gpEngine->GetGraphics()->GetLowLevel()->SetVsyncActive(false, false);
 	gpEngine->SetWaitIfAppOutOfFocus(true);
 	
 

--- a/HPL2/tools/modelview/ModelView.cpp
+++ b/HPL2/tools/modelview/ModelView.cpp
@@ -573,7 +573,8 @@ public:
 	void SetupView()
 	{
 		gpEngine->GetInput()->GetLowLevel()->LockInput(false);
-
+		gpEngine->GetInput()->GetLowLevel()->RelativeMouse(false);
+		
 		cRenderSettings *pSettings = gpSimpleCamera->GetViewport()->GetRenderSettings();
 		gpSimpleCamera->GetViewport()->AddRendererCallback(&renderCallback);
 


### PR DESCRIPTION
This includes a number of fixes specifically for the editors.

* Compilation errors.
* Widgets not being properly destroyed in the level editor.
* Thumbnails in the level editor not being rendered correctly caused by glFinish being commented out.
* Mouse cursor being off screen when launching the model editor.